### PR TITLE
Remove index numbers from images

### DIFF
--- a/src/gui/handler/ui/StartWidget.cpp
+++ b/src/gui/handler/ui/StartWidget.cpp
@@ -190,15 +190,6 @@ void StartWidget::processConfirmDeletionButton() {
     } else  {
         ui->abortDeletionQPushButton->setText("Select all");
     }
-
-    renumerateImages();
-}
-
-void StartWidget::renumerateImages() {
-    for (int i = 0; i < ui->inputImagesQVBoxLayout->count(); ++i) {
-        ((QCheckBox *) (ui->inputImagesQVBoxLayout->itemAt(i)->layout()->itemAt(0)->widget()))->setText(
-            QString::number(i + 1));
-    }
 }
 
 bool StartWidget::areAllSelected() {

--- a/src/gui/handler/ui/StartWidget.h
+++ b/src/gui/handler/ui/StartWidget.h
@@ -90,8 +90,6 @@ private:
 
     void clearLayout(QLayout *layout);
 
-    void renumerateImages();
-
     bool areAllSelected();
 
 public:


### PR DESCRIPTION
The changes in 9a4d9f5860ccf3fd27cf49eb9b7c8f0f80dc458f were incomplete
and if the user removed images via "Remove selected images", the
remaining images were suddenly showing index numbers.

This commit basically reverts all of commit
62c67355af9e06592c76c5555eba199ce88ca5c4.